### PR TITLE
fix-firefox-enter

### DIFF
--- a/src/text/event-hooks/enter-to-create-p.ts
+++ b/src/text/event-hooks/enter-to-create-p.ts
@@ -57,7 +57,9 @@ function enterToCreateP(editor: Editor, enterUpEvents: Function[], enterDownEven
 
     // enter down 时
     function createPWhenEnterText(e: Event) {
-        const $selectElem = editor.selection.getSelectionContainerElem() as DomElement
+        // selection中的range缓存还有问题,更新不及时,此处单独获取range处理enter的bug
+        const range = getSelection()?.getRangeAt(0)
+        const $selectElem = editor.selection.getSelectionContainerElem(range) as DomElement
         if ($selectElem.id === editor.textElemId) {
             // 回车时，默认创建了 text 标签（没有 p 标签包裹），父元素直接就是 $textElem
             // 例如，光标放在 table 最后侧，回车时，默认就是这个情况

--- a/src/text/event-hooks/enter-to-create-p.ts
+++ b/src/text/event-hooks/enter-to-create-p.ts
@@ -57,9 +57,9 @@ function enterToCreateP(editor: Editor, enterUpEvents: Function[], enterDownEven
 
     // enter down 时
     function createPWhenEnterText(e: Event) {
-        // selection中的range缓存还有问题,更新不及时,此处单独获取range处理enter的bug
-        const range = getSelection()?.getRangeAt(0)
-        const $selectElem = editor.selection.getSelectionContainerElem(range) as DomElement
+        // selection中的range缓存还有问题,更新不及时,此处手动更新range,处理enter的bug
+        editor.selection.saveRange(getSelection()?.getRangeAt(0))
+        const $selectElem = editor.selection.getSelectionContainerElem() as DomElement
         if ($selectElem.id === editor.textElemId) {
             // 回车时，默认创建了 text 标签（没有 p 标签包裹），父元素直接就是 $textElem
             // 例如，光标放在 table 最后侧，回车时，默认就是这个情况


### PR DESCRIPTION
修复bug
(选择文本后手动转移光标但仍在之前选区范围内,selection中的选取缓存不更新,因而致使enter删除之前文本)